### PR TITLE
feat: descriptive INFO/DEBUG activity logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,14 @@ All notable changes to this project are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.3.1] — Unreleased
+## [0.3.2] — Unreleased
+
+### Added
+- Descriptive **`INFO`/`DEBUG` activity logging** throughout the SDK — endpoint fetches,
+  per-request method/URL/status/size, auto-pagination progress, combined-dataset builds,
+  and exports. Enable detail with `get_logger("pydoge_api", log_level="DEBUG")`.
+
+## [0.3.1]
 
 ### Changed
 - **Dropped Python 3.8 support** (end-of-life since Oct 2024); `requires-python` is now

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -21,6 +21,41 @@ logger in your own code.
 
 ---
 
+## Tracing what the SDK is doing
+
+The SDK emits structured activity logs so you can see exactly what it's doing:
+
+- **`INFO`** — milestones: each endpoint fetch, auto-pagination start/finish, combined-dataset
+  build, and exports.
+- **`DEBUG`** — detail: every HTTP request/response (method, URL, params, status, size),
+  per-page pagination, `to_dataframe` shape, and client init/close.
+
+Enable `DEBUG` by configuring the logger **before** your first call:
+
+```python
+from pydoge_api import DogeAPI
+from pydoge_api._logging import get_logger
+
+get_logger("pydoge_api", log_level="DEBUG")   # configure once, up front
+
+with DogeAPI(fetch_all=True) as api:
+    api.savings.get_leases(sort_by="savings")
+```
+
+```text
+INFO   🏢 Fetching leases (sort_by='savings', per_page=100, fetch_all=True)
+DEBUG  → GET https://api.doge.gov/savings/leases params={'sort_by': 'savings', 'page': 1, 'per_page': 100}
+DEBUG  ← 200 GET https://api.doge.gov/savings/leases (17460 bytes)
+INFO   📄 Auto-paginating /savings/leases: fetching pages 2–3 (sync)
+DEBUG  /savings/leases: fetching page 2/3
+INFO   ✅ /savings/leases: merged 264 leases from 3 pages
+```
+
+At the default `INFO` level you still get the high-level milestones without the
+per-request noise.
+
+---
+
 ## Getting the logger
 
 ```python

--- a/src/pydoge_api/api.py
+++ b/src/pydoge_api/api.py
@@ -1,5 +1,6 @@
 from typing import Optional
 
+from ._logging import logger
 from .client import DogeAPIClient
 from .endpoints.payments import PaymentsAPI
 from .endpoints.savings import SavingsAPI
@@ -62,10 +63,15 @@ class DogeAPI:
 
         self.savings = SavingsAPI(client=self.client, api=self)
         self.payments = PaymentsAPI(client=self.client, api=self)
+        logger.debug(
+            f"DogeAPI initialized (base_url={self.client.base_url}, fetch_all={fetch_all}, "
+            f"output_pydantic={output_pydantic}, handle_response={handle_response}, run_async={run_async})"
+        )
 
     def close(self):
         """Close the internal client session (unless an external client was injected)."""
         if self._owns_client:
+            logger.debug("Closing DogeAPI client session")
             self.client.close()
 
     def __enter__(self):

--- a/src/pydoge_api/client.py
+++ b/src/pydoge_api/client.py
@@ -71,7 +71,9 @@ class DogeAPIClient:
 
         while retries <= self.max_retries:
             try:
+                logger.debug(f"→ {method} {url} params={kwargs.get('params') or {}}")
                 response = self.client.request(method, url, **kwargs)
+                logger.debug(f"← {response.status_code} {method} {url} ({len(response.content)} bytes)")
                 if response.status_code < 400:
                     return response
                 if response.status_code not in retriable:

--- a/src/pydoge_api/endpoints/payments.py
+++ b/src/pydoge_api/endpoints/payments.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING, Optional, Union, cast
 
 import httpx
 
+from .._logging import logger
 from ..client import DogeAPIClient
 from ..models.payments import PaymentParams, PaymentResponse, PaymentStatisticsResponse
 from ..utils.exporter import handle_dict
@@ -73,6 +74,10 @@ class PaymentsAPI:
         )
         query = params.model_dump(exclude_none=True)
 
+        _flt = f", filter={filter}={filter_value!r}" if filter else ""
+        logger.info(
+            f"🧾 Fetching payments (sort_by={sort_by!r}, per_page={per_page}, fetch_all={self.api.fetch_all}{_flt})"
+        )
         result = self.client.get("/payments", params=query, decode=self.api.handle_response)
         if not self.api.handle_response:
             return result
@@ -103,6 +108,7 @@ class PaymentsAPI:
             plain dict if `output_pydantic=False`,
             or raw response if `handle_response=False`.
         """
+        logger.info("📊 Fetching payment statistics")
         result = self.client.get("/payments/statistics", decode=self.api.handle_response)
         if not self.api.handle_response:
             return result

--- a/src/pydoge_api/endpoints/savings.py
+++ b/src/pydoge_api/endpoints/savings.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Any, Optional, Union, cast
 import httpx
 import pandas as pd
 
+from .._logging import logger
 from ..client import DogeAPIClient
 from ..models.savings import ContractParams, ContractResponse, GrantParams, GrantResponse, LeaseParams, LeaseResponse
 from ..utils.pagination import _fetch_paginated
@@ -58,6 +59,7 @@ class SavingsAPI:
         params = GrantParams(sort_by=sort_by, sort_order=sort_order, page=page, per_page=per_page)
         query = params.model_dump(exclude_none=True)
 
+        logger.info(f"💸 Fetching grants (sort_by={sort_by!r}, per_page={per_page}, fetch_all={self.api.fetch_all})")
         result = self.client.get("/savings/grants", params=query, decode=self.api.handle_response)
         if not self.api.handle_response:
             return result
@@ -101,6 +103,7 @@ class SavingsAPI:
         params = ContractParams(sort_by=sort_by, sort_order=sort_order, page=page, per_page=per_page)
         query = params.model_dump(exclude_none=True)
 
+        logger.info(f"📑 Fetching contracts (sort_by={sort_by!r}, per_page={per_page}, fetch_all={self.api.fetch_all})")
         result = self.client.get("/savings/contracts", params=query, decode=self.api.handle_response)
         if not self.api.handle_response:
             return result
@@ -144,6 +147,7 @@ class SavingsAPI:
         params = LeaseParams(sort_by=sort_by, sort_order=sort_order, page=page, per_page=per_page)
         query = params.model_dump(exclude_none=True)
 
+        logger.info(f"🏢 Fetching leases (sort_by={sort_by!r}, per_page={per_page}, fetch_all={self.api.fetch_all})")
         result = self.client.get("/savings/leases", params=query, decode=self.api.handle_response)
         if not self.api.handle_response:
             return result
@@ -194,6 +198,7 @@ class SavingsAPI:
         ...     df = api.savings.all()
         >>> df.groupby(["kind", "agency"])["savings"].sum()
         """
+        logger.info("🧮 Building combined savings dataset (grants + contracts + leases)")
         frames = []
         for kind, fetch in (
             ("grant", self.get_grants),
@@ -207,5 +212,8 @@ class SavingsAPI:
                 )
             df = cast(Any, resp).to_dataframe(parse_dates=parse_dates)
             df.insert(0, "kind", kind)
+            logger.debug(f"  {kind}: {len(df)} rows")
             frames.append(df)
-        return pd.concat(frames, ignore_index=True)
+        combined = pd.concat(frames, ignore_index=True)
+        logger.info(f"✅ Combined dataset: {len(combined)} rows across {len(frames)} categories")
+        return combined

--- a/src/pydoge_api/utils/async_tools.py
+++ b/src/pydoge_api/utils/async_tools.py
@@ -52,6 +52,7 @@ async def _fetch_grants_pages(client: DogeAPIClient, endpoint: str, params, tota
         Each element is a page's parsed response (dict)
     """
     headers = dict(client.client.headers)
+    logger.debug(f"async: requesting pages 2–{total_pages} concurrently for {endpoint}")
     async with httpx.AsyncClient(base_url=client.base_url, timeout=client.timeout, headers=headers) as async_client:
         tasks = []
         for page in range(2, total_pages + 1):

--- a/src/pydoge_api/utils/exporter.py
+++ b/src/pydoge_api/utils/exporter.py
@@ -6,6 +6,8 @@ from typing import Optional
 import pandas as pd
 from pydantic import BaseModel
 
+from .._logging import logger
+
 #: Columns the DOGE API returns as date strings. They are coerced to ``datetime64``
 #: by :meth:`ExportMixin.to_dataframe` so time-series analysis and plotting work out
 #: of the box. (``date`` — grants/leases; ``payment_date`` — payments;
@@ -54,6 +56,7 @@ class ExportMixin:
         else:
             raise ValueError("Unsupported format. Choose: csv, xlsx, json.")
 
+        logger.info(f"💾 Exported {len(df)} rows to {path}")
         return path
 
     def to_dataframe(self, parse_dates: bool = True) -> pd.DataFrame:
@@ -74,6 +77,7 @@ class ExportMixin:
         df = pd.DataFrame(self._get_collection())
         if parse_dates:
             df = _coerce_dates(df)
+        logger.debug(f"to_dataframe: {len(df)} rows × {len(df.columns)} columns (parse_dates={parse_dates})")
         return df
 
     def summary(self, verbose: bool = False, save_as: Optional[str] = None, to_stdout: bool = True) -> str:

--- a/src/pydoge_api/utils/pagination.py
+++ b/src/pydoge_api/utils/pagination.py
@@ -3,6 +3,7 @@ from typing import Any, Type, TypeVar, Union
 
 from pydantic import BaseModel
 
+from .._logging import logger
 from .async_tools import _fetch_grants_pages, run_async
 from .exporter import handle_dict
 
@@ -49,13 +50,18 @@ def _fetch_paginated(
     # public return type precise (Union[ModelT, dict]).
     resp: Any = initial_response
 
-    if not api.fetch_all or getattr(resp.meta, "pages", 1) <= 1:
+    total_pages = getattr(resp.meta, "pages", 1)
+    if not api.fetch_all or total_pages <= 1:
+        if api.fetch_all:
+            logger.debug(f"{endpoint}: single page, no pagination needed")
         return initial_response if api.output_pydantic else handle_dict(resp.model_dump(exclude_none=True))
 
     all_items = getattr(resp.result, key)
     per_page = params.per_page
     page = params.page
-    total_pages = resp.meta.pages
+
+    mode = "async" if api.run_async else "sync"
+    logger.info(f"📄 Auto-paginating {endpoint}: fetching pages 2–{total_pages} ({mode})")
 
     if api.run_async:
 
@@ -70,6 +76,7 @@ def _fetch_paginated(
             all_items.extend(getattr(page_model.result, key))
     else:
         for p in range(page + 1, total_pages + 1):
+            logger.debug(f"{endpoint}: fetching page {p}/{total_pages}")
             params.page = p
             next_data = client.get(endpoint, params=params.model_dump(exclude_none=True), decode=True)
             next_model: Any = model_cls(**next_data)
@@ -79,5 +86,6 @@ def _fetch_paginated(
     setattr(resp.result, key, all_items)
     resp.meta.total_results = len(all_items)
     resp.meta.pages = ceil(len(all_items) / per_page)
+    logger.info(f"✅ {endpoint}: merged {len(all_items)} {key} from {total_pages} pages")
 
     return initial_response if api.output_pydantic else handle_dict(resp.model_dump(exclude_none=True))


### PR DESCRIPTION
Adds activity logging so users can see what the SDK is doing.

- **INFO** milestones: endpoint fetches, auto-pagination start/finish, combined-dataset build, exports.
- **DEBUG** detail: per-request method/URL/status/size, per-page pagination, async fan-out, to_dataframe shape, client init/close.

Enable detail with `get_logger("pydoge_api", log_level="DEBUG")`; default INFO shows milestones only. Docs section + CHANGELOG 0.3.2 entry. Verified: ruff, mypy, 77 tests, and a live DEBUG trace.

Generated with Claude Code